### PR TITLE
Standardize on the ghcr as the image registry for publishing images.

### DIFF
--- a/.github/actions/build-push-container/action.yaml
+++ b/.github/actions/build-push-container/action.yaml
@@ -15,16 +15,6 @@ inputs:
   github_token:
     description: Github Container Registry Authorization Token
     required: true
-  dockerhub_username:
-    description: Dockerhub Container Registry Username
-    required: false
-  dockerhub_organization:
-    description: Dockerhub Container Registry Organization
-    required: false
-    default: bcgovimages
-  dockerhub_token:
-    description: Dockerhub Container Registry Authorization Token
-    required: false
 
 runs:
   using: composite
@@ -36,7 +26,6 @@ runs:
       shell: bash
       run: |
         echo "GH_USERNAME=$(tr '[:upper:]' '[:lower:]' <<< '${{ inputs.github_username }}')" >> $GITHUB_ENV
-        echo "HAS_DOCKERHUB=${{ fromJson(inputs.dockerhub_username != '' && inputs.dockerhub_token != '') }}" >> $GITHUB_ENV
 
     - name: Login to Github Container Registry
       uses: docker/login-action@v1
@@ -45,21 +34,12 @@ runs:
         username: ${{ env.GH_USERNAME }}
         password: ${{ inputs.github_token }}
 
-    - name: Login to Dockerhub Container Registry
-      if: env.HAS_DOCKERHUB == 'true'
-      uses: docker/login-action@v1
-      with:
-        registry: docker.io
-        username: ${{ inputs.dockerhub_username }}
-        password: ${{ inputs.dockerhub_token }}
-
     - name: Prepare Container Metadata tags
       id: meta
       uses: docker/metadata-action@v3
       with:
         images: |
           ghcr.io/${{ env.GH_USERNAME }}/${{ inputs.image_name }}
-          docker.io/${{ inputs.dockerhub_organization }}/${{ inputs.image_name }},enable=${{ env.HAS_DOCKERHUB }}
         # Always updates the 'latest' tag
         flavor: |
           latest=true

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -25,5 +25,3 @@ jobs:
           image_name: ${{ env.APP_NAME }}
           github_username: ${{ github.repository_owner }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Certbot [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
-[![version](https://img.shields.io/docker/v/bcgovimages/certbot.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/certbot)
-[![pulls](https://img.shields.io/docker/pulls/bcgovimages/certbot.svg)](https://hub.docker.com/r/bcgovimages/certbot)
-[![size](https://img.shields.io/docker/image-size/bcgovimages/certbot.svg)](https://hub.docker.com/r/bcgovimages/certbot)
-
 Automatically update TLS Certificates on OpenShift Routes
 
 _Update (August 2023) - Entrust Certificate Services has discontinued ACMEv1 protocol. Current users of BCDevOps Certbot will be unable to renew their certificates at this time if they are using OCIO Identity Management Services' Entrust Certificate Services._

--- a/charts/certbot/values.yaml
+++ b/charts/certbot/values.yaml
@@ -1,11 +1,11 @@
 image:
-  repository: bcgovimages/certbot
+  repository: bcgov/certbot
   tag: latest
   pullPolicy: Always
 
 artifactoryProxy:
   enabled: false
-  artifactoryPrefix: artifacts.developer.gov.bc.ca/docker-remote
+  artifactoryPrefix: artifacts.developer.gov.bc.ca/github-docker-remote
   # You need to set this if you are using artifactoryProxy.enabled: true
   artifactoryServiceAccount: ~
 
@@ -33,7 +33,7 @@ certbot:
   # Allow domain validation to pass if a subset of them are valid
   subset: true
 
-  # Manage an individual certificate per unique managed host (domain name), if true, 
+  # Manage an individual certificate per unique managed host (domain name), if true,
   # otherwise, manage a single certificate for all managed hosts (domain names)
   certPerHost: false
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,5 @@
 # Certbot [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
-[![version](https://img.shields.io/docker/v/bcgovimages/certbot.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/certbot)
-[![pulls](https://img.shields.io/docker/pulls/bcgovimages/certbot.svg)](https://hub.docker.com/r/bcgovimages/certbot)
-[![size](https://img.shields.io/docker/image-size/bcgovimages/certbot.svg)](https://hub.docker.com/r/bcgovimages/certbot)
-
 Automatically update TLS Certificates on OpenShift Routes
 
 _Update (August 2023) - Entrust Certificate Services has discontinued ACMEv1 protocol. Current users of BCDevOps Certbot will be unable to renew their certificates at this time if they are using OCIO Identity Management Services' Entrust Certificate Services._
@@ -14,17 +10,19 @@ To learn more about the **Common Services** available visit the [Common Services
 
 ## Table of Contents
 
-- [Summary](#summary)
-- [Environment Variables](#environment-variables)
-- [Quick Start](#quick-start)
-  - [Manual Run](#manual-run)
-  - [Cleanup](#cleanup)
-- [Entrust Usage](#entrust-usage)
-- [Tips](#tips)
-- [Appendix](#appendix)
-  - [References](#references)
-  - [Errata](#errata)
-- [License](#license)
+- [Certbot  ](#certbot--)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Environment Variables](#environment-variables)
+  - [Quick Start](#quick-start)
+    - [Manual Run](#manual-run)
+    - [Cleanup](#cleanup)
+  - [Entrust Usage](#entrust-usage)
+  - [Tips](#tips)
+  - [Appendix](#appendix)
+    - [References](#references)
+    - [Errata](#errata)
+  - [License](#license)
 
 ## Summary
 
@@ -89,8 +87,8 @@ The following provides you a quick way to get Certbot set up and running as an O
     | `CERTBOT_CERT_PER_HOST` | `false` | Manage an individual certificate per unique managed host (domain name), if true, otherwise, manage a single certificate for all managed hosts (domain names) |
     | `CRON_SCHEDULE` | `0 0 * * 1,4` | [Cronjob](https://crontab.guru) Schedule |
     | `CRON_SUSPEND` | `false` | Suspend cronjob |
-    | `IMAGE_REGISTRY` | `docker.io` | Image Registry |
-    | `IMAGE_NAMESPACE` | `bcgovimages` | Image Namespace |
+    | `IMAGE_REGISTRY` | `ghcr.io` | Image Registry |
+    | `IMAGE_NAMESPACE` | `bcgov` | Image Namespace |
     | `IMAGE_NAME` | `certbot` | Image Name |
     | `IMAGE_TAG` | `latest` | Image Tag. We recommend pinning this to a specific release veresion for stability |
 

--- a/openshift/certbot.dc.yaml
+++ b/openshift/certbot.dc.yaml
@@ -210,13 +210,13 @@ parameters:
   - name: IMAGE_REGISTRY
     description: Image Registry
     required: true
-    value: docker.io
+    value: ghcr.io
     # Internal OpenShift container registry: image-registry.openshift-image-registry.svc:5000
 
   - name: IMAGE_NAMESPACE
     description: Image Namespace
     required: true
-    value: bcgovimages
+    value: bcgov
 
   - name: IMAGE_NAME
     description: Image Name


### PR DESCRIPTION
Removes all references to the Docker Hub repository since it will cease to exist after the end of March 2025.